### PR TITLE
Add link management api

### DIFF
--- a/golinks.go
+++ b/golinks.go
@@ -54,7 +54,7 @@ func main() {
 	fmt.Printf("Starting http server:\nListening on port :%d\n", port)
 
 	redirector := handler.NewHandler(links.NewLinkMap(configFile))
-	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), *redirector); err != nil {
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), redirector); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -96,12 +96,19 @@ func (h *GolinkHandler) handlePost(w http.ResponseWriter, req *http.Request) {
 	}
 	w.WriteHeader(http.StatusOK)
 	w.Header().Add("Content-Type", "application/json")
-	w.Write(responseBytes)
+	_, err = w.Write(responseBytes)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
 }
 
 func (h *GolinkHandler) handleDelete(w http.ResponseWriter, req *http.Request) {
 	path := strings.TrimPrefix(req.URL.Path, "/")
-	h.linkMap.Delete(path)
+	err := h.linkMap.Delete(path)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -73,13 +73,20 @@ func (h *GolinkHandler) handlePost(w http.ResponseWriter, req *http.Request) {
 			Path:   path,
 			Target: oldTarget.String(),
 		}
-	}
 
-	err = h.linkMap.Put(path, *target)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Printf("Encountered an error writing updates to file: %s\n", err)
-		return
+		err := h.linkMap.Update(path, target)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Printf("Encountered an error updating file :%s\n", err)
+			return
+		}
+	} else {
+		err = h.linkMap.Put(path, target)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Printf("Encountered an error writing updates to file: %s\n", err)
+			return
+		}
 	}
 
 	update := targetUpdate{
@@ -93,12 +100,14 @@ func (h *GolinkHandler) handlePost(w http.ResponseWriter, req *http.Request) {
 	responseBytes, err := json.Marshal(update)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusOK)
 	w.Header().Add("Content-Type", "application/json")
 	_, err = w.Write(responseBytes)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -25,6 +25,7 @@ func NewHandler(linkMapPtr *links.LinkMap) *GolinkHandler {
 }
 
 func (h *GolinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	fmt.Printf("Handling request %s %s\n", req.Method, req.URL.Path)
 	switch req.Method {
 	case http.MethodGet:
 		h.handleGet(w, req)
@@ -52,6 +53,7 @@ func (h *GolinkHandler) handlePost(w http.ResponseWriter, req *http.Request) {
 	_, exists := h.linkMap.Get(path)
 
 	if exists {
+		fmt.Println("Path exists, discarding update.")
 		w.WriteHeader(http.StatusForbidden)
 		return
 	}
@@ -61,6 +63,7 @@ func (h *GolinkHandler) handlePost(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	fmt.Printf("Received update: key:{%s} target:{%s}\n", path, target)
 
 	targetURL, err := url.Parse(target.Target)
 	if err != nil {

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -66,6 +66,7 @@ func findConfig(requestedConfig string) (string, *os.File) {
 		}
 		file, err := openFile(config)
 		if err == nil { // Note the deviation from the standard err != nil
+			fmt.Printf("Using config file %s\n", config)
 			return config, file
 		}
 		errs = append(errs, err)
@@ -142,7 +143,8 @@ func (l *LinkMap) watchConfig(watcher *fsnotify.Watcher) {
 			if err != nil {
 				log.Fatal(err)
 			}
-			if event.Name == name && (event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) {
+			if filepath.Base(event.Name) == name && (event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) {
+				fmt.Println("Config file updated, reloading...")
 				l.update()
 			}
 		case err, ok := <-watcher.Errors:
@@ -163,6 +165,7 @@ func (l *LinkMap) update() {
 
 	l.mapLock.Lock()
 	defer l.mapLock.Unlock()
+	fmt.Printf("Reading config file {%s}\n", l.configPath)
 	l.m = parseConfig(file)
 }
 

--- a/links
+++ b/links
@@ -1,2 +1,1 @@
 test https://www.google.com
-


### PR DESCRIPTION
Fixes #4 

Deviation from spec:
* `POST` is used for all updates, rather than being split between post and patch
* `POST` returns a json response with the old/new values