### PR TITLE
Create different storage backends

### DIFF
--- a/golinks.go
+++ b/golinks.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/dfryer1193/golinks/internal/links/storage"
 	"net/http"
 	"os"
 	"strings"
@@ -23,6 +24,11 @@ Usage: golinks [-port 8080] [-config ./links]
 
 -h                                      Show this help message
 -port <number>                          The port to listen on (default: 8080)
+-storage <FILE|NONE>					The type of storage to use for persistence.
+										Defaults to "FILE". Storage types:
+											* NONE: Provides no persistence
+											* FILE: Persists shortcut entries to the
+													file specified by the -config option
 -config <absolute path to config file>  The path to the preferred config file.
                                         If this file is not present, falls back
                                         to default locations in the following
@@ -30,6 +36,7 @@ Usage: golinks [-port 8080] [-config ./links]
                                             * "./links"
                                             * "~/.config/golinks/links"
                                             * "/etc/golinks/links"
+-level <loglevel>						The loglevel to log at. Defaults to "INFO"
 
 Config format:
 The config file is a simple plaintext file consisting of one key/value pair per
@@ -47,10 +54,12 @@ respected, though full paths are.
 
 func main() {
 	var port int
+	var storageTypeString string
 	var configFile string
 	var stringLogLevel string
 	flag.IntVar(&port, "port", 8080, "The port to listen on")
-	flag.StringVar(&configFile, "config", "", "Location of the config file")
+	flag.StringVar(&storageTypeString, "storage", "FILE", "The type of storage to use for persistence")
+	flag.StringVar(&configFile, "config", "", "Location of the config file. Ignored if storageType is 'NONE'")
 	flag.StringVar(&stringLogLevel, "level", "INFO", "The level to log at")
 	flag.Usage = help
 
@@ -63,10 +72,11 @@ func main() {
 	level := getLevelFromArg(stringLogLevel)
 	log.Info().Str("loglevel", level.String()).Msg("Setting log level...")
 	zerolog.SetGlobalLevel(level)
+	storageType := storage.FromString(storageTypeString)
 
 	log.Info().Int("port", port).Msg("Starting http server")
 
-	redirector := handler.NewGolinkHandler(links.NewLinkMap(configFile))
+	redirector := handler.NewGolinkHandler(links.NewLinkMap(storageType, configFile))
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", port), redirector); err != nil {
 		log.Fatal().Err(err)
 	}

--- a/golinks.go
+++ b/golinks.go
@@ -24,11 +24,11 @@ Usage: golinks [-port 8080] [-config ./links]
 
 -h                                      Show this help message
 -port <number>                          The port to listen on (default: 8080)
--storage <FILE|NONE>					The type of storage to use for persistence.
-										Defaults to "FILE". Storage types:
-											* NONE: Provides no persistence
-											* FILE: Persists shortcut entries to the
-													file specified by the -config option
+-storage <FILE|NONE>                    The type of storage to use for persistence.
+                                        Defaults to "FILE". Storage types:
+                                            * NONE: Provides no persistence
+                                            * FILE: Persists shortcut entries to the
+                                                    file specified by the -config option
 -config <absolute path to config file>  The path to the preferred config file.
                                         If this file is not present, falls back
                                         to default locations in the following
@@ -36,12 +36,12 @@ Usage: golinks [-port 8080] [-config ./links]
                                             * "./links"
                                             * "~/.config/golinks/links"
                                             * "/etc/golinks/links"
--level <loglevel>						The loglevel to log at. Defaults to "INFO"
+-level <loglevel>                       The loglevel to log at. Defaults to "INFO"
 
 Config format:
 The config file is a simple plaintext file consisting of one key/value pair per
 line, separated by spaces, like so:
-	
+
     test https://www.google.com
 
 The value of the pair must be a full web address. Query params are not

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -1,18 +1,9 @@
 package links
 
 import (
-	"bufio"
-	"fmt"
+	"github.com/dfryer1193/golinks/internal/links/storage"
 	"net/url"
-	"os"
-	"os/user"
-	"path/filepath"
-	"strings"
 	"sync"
-	"unicode"
-
-	"github.com/fsnotify/fsnotify"
-	"github.com/rs/zerolog/log"
 )
 
 type ParseError struct{}
@@ -20,173 +11,68 @@ type ParseError struct{}
 // LinkMap houses the map of redirects, and keeps track of the backing file for
 // maintaining the map across restarts. It also handles thread safety.
 type LinkMap struct {
-	configPath string
-	m          map[string]string
-	mapLock    *sync.RWMutex
-	fileLock   *sync.RWMutex
+	store   storage.Storage
+	m       map[string]string
+	mapLock *sync.RWMutex
 }
 
 // NewLinkMap generates a new LinkMap object, with the requested config if it
 // exists. If the requested config does not exist, it falls back to the default
 // locations. If the default locations do not exist, the program will exit with
 // an error.
-func NewLinkMap(requestedConfig string) *LinkMap {
-	path, config := findConfig(requestedConfig)
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		log.Fatal().Err(err).Msg("Error creating file watcher")
-	}
+func NewLinkMap(persistType storage.StorageType, requestedConfig string) *LinkMap {
+	store := buildStorage(persistType, requestedConfig)
 
 	linkMap := LinkMap{
-		configPath: path,
-		m:          parseConfig(config),
-		mapLock:    &sync.RWMutex{},
-		fileLock:   &sync.RWMutex{},
+		store:   store,
+		m:       store.Read(),
+		mapLock: &sync.RWMutex{},
 	}
 
-	go linkMap.watchConfig(watcher)
+	go linkMap.handleReload()
 
 	return &linkMap
 }
 
-func getHomeDir() string {
-	currentUser, err := user.Current()
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to get current user")
+func buildStorage(persistType storage.StorageType, requestedConfig string) storage.Storage {
+	switch persistType {
+	case storage.NONE:
+		return storage.NewNoneStorage()
+	case storage.FILE:
+		return storage.NewFileStorage(requestedConfig)
+	default:
+		return storage.NewFileStorage("")
 	}
-
-	return currentUser.HomeDir
 }
 
-func findConfig(requestedConfig string) (string, *os.File) {
-	homedir := getHomeDir()
-	configs := []string{
-		requestedConfig,
-		"./links",
-		homedir + "/.config/golinks/links",
-		"/etc/golinks/links",
-	}
-	errs := []error{}
-
-	for _, config := range configs {
-		if config == "" {
-			continue
-		}
-		file, err := openFile(config)
-		if err == nil { // Note the deviation from the standard err != nil
-			log.Info().Msg("Using config file " + config)
-			return config, file
-		}
-		errs = append(errs, err)
+func (l *LinkMap) handleReload() {
+	reloadChannel := l.store.GetReloadChannel()
+	// If we don't receive a reload channel, we will never receive updates, so we can just stop watching
+	if reloadChannel == nil {
+		return
 	}
 
-	for _, err := range errs {
-		log.Err(err)
-	}
-	log.Fatal().Msg("Failed to find any config")
-	return "", nil
-}
-
-func openFile(path string) (*os.File, error) {
-	fpath, err := filepath.Abs(path)
-	if err != nil {
-		return nil, err
-	}
-
-	file, err := os.OpenFile(fpath, os.O_RDONLY, 0644)
-	if err != nil {
-		return nil, err
-	}
-
-	return file, nil
-}
-
-func parseLine(line string, lineNum int) (string, *url.URL) {
-	parts := strings.FieldsFunc(strings.TrimSpace(line), func(c rune) bool { return unicode.IsSpace(c) })
-	if len(parts) != 2 {
-		if len(parts) == 0 {
-			return "", nil
-		}
-		err := &ParseError{}
-		log.Fatal().Err(err).Int("line", lineNum).Msg("Malformed config. Each non-empty line must have exactly two entries.")
-		panic(1)
-	}
-
-	target, err := url.Parse(parts[1])
-	if err != nil {
-		log.Err(err).Int("line", lineNum).Str("url", parts[1]).Msg("Malformed config. Invalid url")
-	}
-
-	return parts[0], target
-}
-
-func parseConfig(filePtr *os.File) map[string]string {
-	linkMap := make(map[string]string)
-	defer filePtr.Close()
-
-	scanner := bufio.NewScanner(filePtr)
-
-	lineNum := 0
-	for scanner.Scan() {
-		txt := scanner.Text()
-		lineNum++
-		key, target := parseLine(txt, lineNum)
-		if key == "" && target == nil {
-			continue
-		}
-		linkMap[key] = target.String()
-	}
-
-	return linkMap
-}
-
-func (l *LinkMap) watchConfig(watcher *fsnotify.Watcher) {
-	dir := filepath.Dir(l.configPath)
-	name := filepath.Base(l.configPath)
-	err := watcher.Add(dir)
-	if err != nil {
-		log.Err(err).Msg("Failed to add watcher on config dir. Config will not live reload")
-	}
 	for {
 		select {
-		case event, ok := <-watcher.Events:
-			if !ok {
-				return
+		case signal := <-reloadChannel:
+			if signal {
+				l.reload()
 			}
-			log.Debug().Msg("File watch event received!")
-			if filepath.Base(event.Name) == name && (event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) {
-				log.Debug().Msg("Config file updated, reloading...")
-				l.update()
-			}
-		case err, ok := <-watcher.Errors:
-			if !ok {
-				return
-			}
-			if err != nil {
-				log.Err(err).Msg("File watch error received")
-			}
-			fmt.Println(err)
 		}
 	}
 }
 
-func (l *LinkMap) update() {
-	file, err := os.OpenFile(l.configPath, os.O_RDONLY, 0644)
-	if err != nil {
-		log.Fatal().Err(err).Str("file", l.configPath).Msg("Cound not open config for reading")
-	}
-	defer file.Close()
-
+func (l *LinkMap) reload() {
 	l.mapLock.Lock()
 	defer l.mapLock.Unlock()
-	log.Debug().Str("file", l.configPath).Msg("Reading config file")
-	l.m = parseConfig(file)
+	l.m = l.store.Read()
 }
 
 // Get returns the url and state of existence for a single key.
 func (l *LinkMap) Get(key string) (string, bool) {
 	l.mapLock.RLock()
 	defer l.mapLock.RUnlock()
+
 	target, exists := l.m[key]
 	return target, exists
 }
@@ -227,18 +113,7 @@ func (l *LinkMap) GetFiltered(keys []string) map[string]string {
 // be duplicated in the backing file, and the value in the live map will be
 // replaced.
 func (l *LinkMap) Put(key string, target *url.URL) error {
-	l.fileLock.Lock()
-	defer l.fileLock.Unlock()
-
-	file, err := os.OpenFile(l.configPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	if _, err := file.WriteString(key + " " + target.String() + "\n"); err != nil {
-		return err
-	}
+	go l.store.Put(key, target.String())
 
 	l.mapLock.Lock()
 	defer l.mapLock.Unlock()
@@ -257,98 +132,22 @@ func (l *LinkMap) Delete(key string) error {
 	}
 	l.mapLock.RUnlock()
 
-	err := l.updateEntry(key, nil)
-	if err != nil {
-		return err
-	}
-
+	go l.store.Delete(key)
+	l.mapLock.Lock()
+	delete(l.m, key)
+	l.mapLock.Unlock()
 	return nil
 }
 
 // Update updates an existing entry in the link map. This should only be used to
 // update existing entries, as Put is much more efficient for additions.
 func (l *LinkMap) Update(key string, target *url.URL) error {
-	err := l.updateEntry(key, target)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (l *LinkMap) updateEntry(key string, target *url.URL) error {
-	l.fileLock.Lock()
-	curFile, err := os.OpenFile(l.configPath, os.O_RDONLY, 0600)
-	if err != nil {
-		return err
-	}
-
-	newFile, err := os.OpenFile(l.getScratchConfigFilepath(), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		return err
-	}
-
-	scanner := bufio.NewScanner(curFile)
-	for scanner.Scan() {
-		txt := scanner.Text()
-		if strings.HasPrefix(txt, key+" ") {
-			if target == nil {
-				continue
-			}
-			if _, err := newFile.WriteString(key + " " + target.String() + "\n"); err != nil {
-				return err
-			}
-			continue
-		}
-		_, err := newFile.WriteString(txt + "\n")
-		if err != nil {
-			fmt.Println(err)
-			return err
-		}
-	}
-	curFile.Close()
-	newFile.Close()
-	l.fileLock.Unlock()
+	go l.store.Update(key, target.String())
 
 	l.mapLock.Lock()
 	defer l.mapLock.Unlock()
-	if target == nil {
-		delete(l.m, key)
-	} else {
-		l.m[key] = target.String()
-	}
 
-	err = l.replaceConfigInPlace()
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (l *LinkMap) getScratchConfigFilepath() string {
-	return l.configPath + "~"
-}
-
-func (l *LinkMap) getBackupConfigFilepath() string {
-	return l.configPath + ".bak"
-}
-
-func (l *LinkMap) replaceConfigInPlace() error {
-	l.fileLock.Lock()
-	defer l.fileLock.Unlock()
-	err := os.Rename(l.configPath, l.getBackupConfigFilepath())
-	if err != nil {
-		return err
-	}
-	err = os.Rename(l.getScratchConfigFilepath(), l.configPath)
-	if err != nil {
-		return err
-	}
-	err = os.Remove(l.getBackupConfigFilepath())
-	if err != nil {
-		return err
-	}
+	l.m[key] = target.String()
 	return nil
 }
 

--- a/internal/links/storage/common.go
+++ b/internal/links/storage/common.go
@@ -1,5 +1,10 @@
 package storage
 
+import (
+	"github.com/rs/zerolog/log"
+	"strings"
+)
+
 type Storage interface {
 	Read() map[string]string
 	Put(key string, target string)
@@ -14,6 +19,23 @@ const (
 	NONE StorageType = iota
 	FILE
 )
+
+func (st StorageType) String() string {
+	return [...]string{"NONE", "FILE"}[st]
+}
+
+func FromString(s string) StorageType {
+	sanitized := strings.ToUpper(s)
+	switch sanitized {
+	case "NONE":
+		return NONE
+	case "FILE":
+		return FILE
+	default:
+		log.Fatal().Str("requestedStorageType", s).Msg("Storage type not recognized")
+	}
+	return FILE
+}
 
 type ParseError struct{}
 

--- a/internal/links/storage/common.go
+++ b/internal/links/storage/common.go
@@ -1,0 +1,22 @@
+package storage
+
+type Storage interface {
+	Read() map[string]string
+	Put(key string, target string)
+	Delete(key string)
+	Update(key string, target string)
+	GetReloadChannel() <-chan bool
+}
+
+type StorageType int
+
+const (
+	NONE StorageType = iota
+	FILE
+)
+
+type ParseError struct{}
+
+func (e *ParseError) Error() string {
+	return "Failed to parse config"
+}

--- a/internal/links/storage/file.go
+++ b/internal/links/storage/file.go
@@ -1,0 +1,287 @@
+package storage
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/fsnotify/fsnotify"
+	"github.com/rs/zerolog/log"
+	"net/url"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+type FileStorage struct {
+	configPath    string
+	fileLock      *sync.RWMutex
+	watcher       *fsnotify.Watcher
+	reloadChannel chan bool
+}
+
+func NewFileStorage(configPath string) *FileStorage {
+	path := findConfig(configPath)
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error creating file watcher")
+	}
+
+	storage := &FileStorage{
+		configPath:    path,
+		fileLock:      &sync.RWMutex{},
+		watcher:       watcher,
+		reloadChannel: make(chan bool),
+	}
+
+	go storage.watchConfig()
+
+	return storage
+}
+
+func (f *FileStorage) watchConfig() {
+	dir := filepath.Dir(f.configPath)
+	name := filepath.Base(f.configPath)
+	err := f.watcher.Add(dir)
+	if err != nil {
+		log.Err(err).Msg("Failed to add watcher on config dir. Config will not live reload")
+	}
+	for {
+		select {
+		case event, ok := <-f.watcher.Events:
+			if !ok {
+				return
+			}
+			log.Debug().Msg("File watch event received!")
+			if filepath.Base(event.Name) == name && (event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) {
+				log.Debug().Msg("Config file updated, reloading...")
+				f.reloadChannel <- true
+			}
+		case err, ok := <-f.watcher.Errors:
+			if !ok {
+				return
+			}
+			if err != nil {
+				log.Err(err).Msg("File watch error received")
+			}
+			fmt.Println(err)
+		}
+	}
+}
+
+func getHomeDir() string {
+	currentUser, err := user.Current()
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to get current user")
+	}
+
+	return currentUser.HomeDir
+}
+
+func findConfig(requestedConfig string) string {
+	homedir := getHomeDir()
+	configs := []string{
+		requestedConfig,
+		"./links",
+		homedir + "/.config/golinks/links",
+		"/etc/golinks/links",
+	}
+	errs := []error{}
+
+	for _, config := range configs {
+		if config == "" {
+			continue
+		}
+		file, err := openFile(config)
+		if err == nil { // Note the deviation from the standard err != nil
+			log.Info().Msg("Using config file " + config)
+			file.Close()
+			return config
+		}
+		errs = append(errs, err)
+	}
+
+	for _, err := range errs {
+		log.Err(err)
+	}
+	log.Fatal().Msg("Failed to find any config")
+	panic(errs)
+}
+
+func openFile(path string) (*os.File, error) {
+	fpath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	file, err := os.OpenFile(fpath, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func parseLine(line string, lineNum int) (string, *url.URL) {
+	parts := strings.FieldsFunc(strings.TrimSpace(line), func(c rune) bool { return unicode.IsSpace(c) })
+	if len(parts) != 2 {
+		if len(parts) == 0 {
+			return "", nil
+		}
+		err := &ParseError{}
+		log.Fatal().Err(err).Int("line", lineNum).Msg("Malformed config. Each non-empty line must have exactly two entries.")
+		panic(1)
+	}
+
+	target, err := url.Parse(parts[1])
+	if err != nil {
+		log.Err(err).Int("line", lineNum).Str("url", parts[1]).Msg("Malformed config. Invalid url")
+	}
+
+	return parts[0], target
+}
+
+func (f *FileStorage) Read() map[string]string {
+	linkMap := make(map[string]string)
+	filePtr, err := openFile(f.configPath)
+	if err != nil {
+		log.Error().Err(err).Str("file path", f.configPath).Msg("Failed to open file for reading")
+		return linkMap
+	}
+	defer filePtr.Close()
+
+	scanner := bufio.NewScanner(filePtr)
+
+	lineNum := 0
+	for scanner.Scan() {
+		txt := scanner.Text()
+		lineNum++
+		key, target := parseLine(txt, lineNum)
+		if key == "" && target == nil {
+			continue
+		}
+		linkMap[key] = target.String()
+	}
+
+	return linkMap
+}
+
+// Put appends a new entry to the link config. If the entry already exists, it will be duplicated in the file.
+func (f *FileStorage) Put(key string, target string) {
+	f.fileLock.Lock()
+	defer f.fileLock.Unlock()
+
+	file, err := os.OpenFile(f.configPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		log.
+			Error().
+			Err(err).
+			Str("file path", f.configPath).
+			Msg("Failed to open file for writing")
+		return
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(key + " " + target + "\n"); err != nil {
+		log.
+			Error().
+			Err(err).
+			Str("file path", f.configPath).
+			Str("key", key).
+			Str("target", target).
+			Msg("Failed to write to file")
+	}
+
+}
+
+func (f *FileStorage) Delete(key string) {
+	err := f.updateEntry(key, "")
+	if err != nil {
+		log.
+			Error().
+			Err(err).
+			Str("key", key).
+			Msg("Failed to delete key")
+	}
+}
+
+func (f *FileStorage) Update(key string, target string) {
+	err := f.updateEntry(key, target)
+	if err != nil {
+		log.
+			Error().
+			Err(err).
+			Str("key", key).
+			Str("target", target).
+			Msg("Failed to update key")
+	}
+}
+
+func (f *FileStorage) updateEntry(key string, target string) error {
+	f.fileLock.Lock()
+
+	curFile, err := os.OpenFile(f.configPath, os.O_RDONLY, 0600)
+	if err != nil {
+		return err
+	}
+
+	newFile, err := os.OpenFile(f.getScratchConfigFilepath(), os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(curFile)
+	for scanner.Scan() {
+		txt := scanner.Text()
+		if strings.HasPrefix(txt, key+" ") {
+			if target == "" {
+				continue
+			}
+			if _, err := newFile.WriteString(key + " " + target + "\n"); err != nil {
+				return err
+			}
+			continue
+		}
+		_, err := newFile.WriteString(txt + "\n")
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+	}
+	curFile.Close()
+	newFile.Close()
+	f.fileLock.Unlock()
+
+	return nil
+}
+
+func (f *FileStorage) getScratchConfigFilepath() string {
+	return f.configPath + "~"
+}
+
+func (f *FileStorage) getBackupConfigFilepath() string {
+	return f.configPath + ".bak"
+}
+
+func (f *FileStorage) replaceConfigInPlace() error {
+	f.fileLock.Lock()
+	defer f.fileLock.Unlock()
+	err := os.Rename(f.configPath, f.getBackupConfigFilepath())
+	if err != nil {
+		return err
+	}
+	err = os.Rename(f.getScratchConfigFilepath(), f.configPath)
+	if err != nil {
+		return err
+	}
+	err = os.Remove(f.getBackupConfigFilepath())
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *FileStorage) GetReloadChannel() <-chan bool {
+	return f.reloadChannel
+}

--- a/internal/links/storage/none.go
+++ b/internal/links/storage/none.go
@@ -1,0 +1,24 @@
+package storage
+
+type NoneStorage struct{}
+
+func NewNoneStorage() *NoneStorage {
+	return &NoneStorage{}
+}
+
+func (s *NoneStorage) Read() map[string]string {
+	return nil
+}
+
+func (s *NoneStorage) Put(key string, target string) {
+}
+
+func (s *NoneStorage) Delete(key string) {
+}
+
+func (s *NoneStorage) Update(key string, value string) {
+}
+
+func (s *NoneStorage) GetReloadChannel() <-chan bool {
+	return nil
+}


### PR DESCRIPTION
Separates the map from the storage logic.

Creates two different storage backends:

* `NoneStorage`, which is an in-memory storage module with no persistence
* `FileStorage`, which uses a config file to persist across restarts - this also provides a way to live update the map when the backing file changes